### PR TITLE
Hotfix/checkbox alignment

### DIFF
--- a/src/App/Documentation/components/Forms/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Forms/__snapshots__/index.test.js.snap
@@ -20,8 +20,12 @@ exports[`Documentation: Forms Checkboxes renders 1`] = `
       label="Bread"
     />
     <Checkbox
-      checked={true}
       id="checkbox-example-2"
+      label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long."
+    />
+    <Checkbox
+      checked={true}
+      id="checkbox-example-3"
       label="Milk"
     />
   </ComponentPreview>
@@ -49,9 +53,14 @@ exports[`Documentation: Forms DisabledCheckboxes renders 1`] = `
       label="Bread"
     />
     <Checkbox
+      disabled={true}
+      id="checkbox-example-2"
+      label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long."
+    />
+    <Checkbox
       checked={true}
       disabled={true}
-      id="checkbox-disabled-example-2"
+      id="checkbox-disabled-example-3"
       label="Milk"
     />
   </ComponentPreview>

--- a/src/App/Documentation/components/Forms/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Forms/__snapshots__/index.test.js.snap
@@ -54,7 +54,7 @@ exports[`Documentation: Forms DisabledCheckboxes renders 1`] = `
     />
     <Checkbox
       disabled={true}
-      id="checkbox-example-2"
+      id="checkbox-disabled-example-2"
       label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long."
     />
     <Checkbox

--- a/src/App/Documentation/components/Forms/index.js
+++ b/src/App/Documentation/components/Forms/index.js
@@ -219,7 +219,8 @@ const Checkboxes = () => (
         <p>Checkboxes...</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <Checkbox label="Bread" id="checkbox-example-1" />
-            <Checkbox label="Milk" id="checkbox-example-2" checked />
+            <Checkbox label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long." id="checkbox-example-2" />
+            <Checkbox label="Milk" id="checkbox-example-3" checked />
         </ComponentPreview>
     </>
 );
@@ -230,7 +231,8 @@ const DisabledCheckboxes = () => (
         <p>Disabled checkboxes...</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <Checkbox label="Bread" id="checkbox-disabled-example-1" disabled />
-            <Checkbox label="Milk" id="checkbox-disabled-example-2" disabled checked />
+            <Checkbox label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long." id="checkbox-example-2" disabled />
+            <Checkbox label="Milk" id="checkbox-disabled-example-3" disabled checked />
         </ComponentPreview>
     </>
 );

--- a/src/App/Documentation/components/Forms/index.js
+++ b/src/App/Documentation/components/Forms/index.js
@@ -231,7 +231,7 @@ const DisabledCheckboxes = () => (
         <p>Disabled checkboxes...</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <Checkbox label="Bread" id="checkbox-disabled-example-1" disabled />
-            <Checkbox label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long." id="checkbox-example-2" disabled />
+            <Checkbox label="Not bread. I'm not really fond of it. What I would really like, however, is one single piece of cracker with some nutella on it. Perhaps this could be the second checkbox. These thoughts are written here simply to show you how the checkboxes align themselves when label text is fairly long." id="checkbox-disabled-example-2" disabled />
             <Checkbox label="Milk" id="checkbox-disabled-example-3" disabled checked />
         </ComponentPreview>
     </>

--- a/src/less/components/forms.less
+++ b/src/less/components/forms.less
@@ -21,7 +21,6 @@ fieldset {
 
     &:disabled {
         .checkbox input[type=checkbox] {
-
             + label:before {
                 background-color: @input-bg-disabled;
                 border-color: @input-checked-bg-disabled;

--- a/src/less/components/forms.less
+++ b/src/less/components/forms.less
@@ -21,18 +21,21 @@ fieldset {
 
     &:disabled {
         .checkbox input[type=checkbox] {
-            &:after {
+
+            + label:before {
                 background-color: @input-bg-disabled;
                 border-color: @input-checked-bg-disabled;
+                cursor: not-allowed;
             }
 
-            &:checked:after {
+            &:checked + label:before {
                 background-color: @input-checked-bg-disabled;
             }
 
             + label,
+            + label:before,
             &:after,
-            &:checked:after {
+            &:checked + label:before {
                 cursor: not-allowed;
             }
         }
@@ -212,7 +215,7 @@ legend {
     align-items: center;
 
     &:not(:last-child) {
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.6rem;
     }
 
     label {
@@ -223,17 +226,15 @@ legend {
     }
 
     input[type=checkbox] {
-        position: relative;
-        height: @checkbox-height;
-        width: @checkbox-width;
-        margin-right: 0.5rem;
+        margin-right: 1rem;
+        opacity: 0;
 
         + label:before {
             content: "";
             display: block;
             position: absolute;
             visibility: visible;
-            left: -30px;
+            left: -28px;
             height: @checkbox-height;
             width: @checkbox-width;
             background-color: @white;
@@ -246,6 +247,10 @@ legend {
             background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJCAYAAAALpr0TAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAACOSURBVChTfc+xDYJAFIdxCktLCwoLBmAESwoGMLF1BFomYAjHcABdxcrCwoKSmOP7LncJRuI/+cHLuwc8ihDCPzvU1muH2QY3jGjWBrILzBNVbu5RplodzIQD4qcbvHG1gRYOmDPiw15c+AXTw53MgDikXBxhPunu2/2Zn0HdYR7YYnn2NegKJ1SLXhKKGZDpJWzFmbqTAAAAAElFTkSuQmCC);
             background-position: 50% 50%;
             background-repeat: no-repeat;
+        }
+
+        &:focus + label:before {
+            .tab-focus();
         }
 
         &[disabled] {
@@ -275,7 +280,7 @@ legend {
     align-items: center;
 
     &:not(:last-child) {
-        margin-bottom: 0.5rem;
+        margin-bottom: 0.6rem;
     }
 
     label {
@@ -286,7 +291,7 @@ legend {
     }
 
     input[type=radio] {
-        margin-right: 0.6rem;
+        margin-right: 1rem;
         opacity: 0;
 
         + label:before {


### PR DESCRIPTION
Added crossbrowser multiline support. If the label linebreaks, positionings are no longer off. Also fixed checkboxes not being properly disabled if parent fieldset _is_.