### PR TITLE
Quickfix for progress tracker responsiveness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed issue with links not taking browser window to the top within the documentation.
 - Fixed issue with loader element in button loaders.
+- Fixed issue with the Progress tracker component responsiveness.
 
 
 ## [0.9.0] - 2018-08-22

--- a/src/less/components/progress-tracker.less
+++ b/src/less/components/progress-tracker.less
@@ -12,8 +12,10 @@ ol.progress-tracker {
 @media screen and (max-width: @screen-xs-max) {
     ul.progress-tracker,
     ol.progress-tracker {
+        display: block;
+
         li {
-            text-transform: uppercase;
+            display: inline-block;
 
             &.active {
                 font-weight: bold;


### PR DESCRIPTION
Basically quickfix from this:

![pr1](https://user-images.githubusercontent.com/26485094/44576579-34098080-a78f-11e8-9cb6-d5677455b8a4.JPG)

to this:

![pr2](https://user-images.githubusercontent.com/26485094/44576595-38ce3480-a78f-11e8-8862-e2b3b48ebc75.JPG)
