### PR TITLE
Feature/form group margin increase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Changed
 
+- Slightly increased the bottom margin on all form fields to allow for better grouping and spacing for data attribute messages.
+
 ### Fixed
 
 ### Removed

--- a/src/less/components/forms/form.less
+++ b/src/less/components/forms/form.less
@@ -214,7 +214,7 @@ legend {
 }
 
 .form-group {
-    margin-bottom: @base-margin;
+    margin-bottom: @base-margin-lg;
 }
 
 .checkbox,


### PR DESCRIPTION
Increase form group bottom margin to allow for error and success data attribute messages to appear more grouped with their respective form groups.

From this:
![dg01](https://user-images.githubusercontent.com/26485094/48944590-9ce7cc80-ef27-11e8-893f-463020fcbc80.JPG)

To this:
![dg02](https://user-images.githubusercontent.com/26485094/48944599-a2451700-ef27-11e8-8b12-b1ae70bcaaa2.JPG)

