### PR TITLE
Fix/sidebar scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1360,7 +1360,7 @@
                 "@sentry/core": "4.4.2",
                 "@sentry/types": "4.4.2",
                 "@sentry/utils": "4.4.2",
-                "tslib": "^1.9.3"
+                "tslib": "1.9.3"
             }
         },
         "@sentry/cli": {
@@ -1387,7 +1387,7 @@
                 "@sentry/minimal": "4.4.2",
                 "@sentry/types": "4.4.2",
                 "@sentry/utils": "4.4.2",
-                "tslib": "^1.9.3"
+                "tslib": "1.9.3"
             }
         },
         "@sentry/hub": {
@@ -1398,7 +1398,7 @@
             "requires": {
                 "@sentry/types": "4.4.2",
                 "@sentry/utils": "4.4.2",
-                "tslib": "^1.9.3"
+                "tslib": "1.9.3"
             }
         },
         "@sentry/minimal": {
@@ -1409,7 +1409,7 @@
             "requires": {
                 "@sentry/hub": "4.4.2",
                 "@sentry/types": "4.4.2",
-                "tslib": "^1.9.3"
+                "tslib": "1.9.3"
             }
         },
         "@sentry/types": {
@@ -1425,7 +1425,7 @@
             "dev": true,
             "requires": {
                 "@sentry/types": "4.4.2",
-                "tslib": "^1.9.3"
+                "tslib": "1.9.3"
             }
         },
         "@sentry/webpack-plugin": {

--- a/src/less/themes/documentation.less
+++ b/src/less/themes/documentation.less
@@ -38,7 +38,7 @@
 
     .documentation-nav {
         padding: @base-padding;
-        height: calc(100vh - 220px);
+        max-height: calc(100vh - 220px);
         overflow-y: auto;
 
         .nav-group {

--- a/src/less/themes/documentation.less
+++ b/src/less/themes/documentation.less
@@ -38,6 +38,8 @@
 
     .documentation-nav {
         padding: @base-padding;
+        height: calc(100vh - 220px);
+        overflow-y: auto;
 
         .nav-group {
             margin-bottom: @base-margin;


### PR DESCRIPTION
Made documentation-nav have a max-height of 100vh - 220 and added overflow-y:auto. The 220 pixels are to account for the topbar, the banner and the searchbar. The only problem is when you scroll the banner out of view the sidebar could be longer.