### PR TITLE
Add cleanup function and tests for px.datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@
 
 ### Fixed
 
+- datepicker.init() now deletes existing flatpickr instances when init is called more than once.
+
 ### Removed

--- a/src/App/components/FormComponents/Datepicker.js
+++ b/src/App/components/FormComponents/Datepicker.js
@@ -4,6 +4,7 @@ import { Addon } from "@/InputGroup";
 
 const Datepicker = ({ format, time, min, max, months, value, label, prefixValue, prefixType, fulldate, mode, allowinput, required, id }) => {
     const attrs = {
+        id,
         className: "form-control",
         type: "text",
         "data-datepicker": "",
@@ -16,8 +17,7 @@ const Datepicker = ({ format, time, min, max, months, value, label, prefixValue,
         "data-datepicker-fulldate": fulldate || null,
         "data-datepicker-mode": mode || null,
         "data-datepicker-allowinput": allowinput || null,
-        "data-required": required || null,
-        id
+        "data-required": required || null
     };
 
     return (

--- a/src/px-script/main/datepicker/index.js
+++ b/src/px-script/main/datepicker/index.js
@@ -72,6 +72,11 @@ const init = id => {
             return null;
         }
 
+        _datepickers.forEach((d, i) => (d.element.id === id
+            ? (d.destroy(), _datepickers.splice(i, 1))
+            : null)
+        );
+
         return _createDatepicker(datepicker);
     } else {
         const datepickers = document.querySelectorAll(SELECTORS.DATEPICKER);
@@ -82,7 +87,7 @@ const init = id => {
             return null;
         }
 
-        if (_datepickers.length) { _destroyDatepickers(); }
+        _destroyDatepickers();
 
         return [...datepickers].map(datepicker => _createDatepicker(datepicker));
     }

--- a/src/px-script/main/datepicker/index.js
+++ b/src/px-script/main/datepicker/index.js
@@ -5,7 +5,7 @@ const SELECTORS = {
     DATEPICKER: "[data-datepicker]"
 };
 
-const _datepickers = _datepickers || [];
+let _datepickers = _datepickers || [];
 
 // 080989◢◤200418
 const _createDatepicker = datepicker => {
@@ -59,6 +59,7 @@ const _createDatepicker = datepicker => {
 
 const _destroyDatepickers = () => {
     _datepickers.forEach(datepicker => datepicker.destroy());
+    _datepickers = [];
 };
 
 const init = id => {
@@ -70,8 +71,6 @@ const init = id => {
 
             return null;
         }
-
-        if (_datepickers.length) { _destroyDatepickers(); }
 
         return _createDatepicker(datepicker);
     } else {

--- a/src/px-script/main/datepicker/index.js
+++ b/src/px-script/main/datepicker/index.js
@@ -57,6 +57,10 @@ const _createDatepicker = datepicker => {
     return datepickerObj;
 };
 
+const _destroyDatepickers = () => {
+    _datepickers.forEach(datepicker => datepicker.destroy());
+};
+
 const init = id => {
     if (id) {
         const datepicker = document.getElementById(id);
@@ -67,6 +71,8 @@ const init = id => {
             return null;
         }
 
+        if (_datepickers.length) { _destroyDatepickers(); }
+
         return _createDatepicker(datepicker);
     } else {
         const datepickers = document.querySelectorAll(SELECTORS.DATEPICKER);
@@ -76,6 +82,8 @@ const init = id => {
 
             return null;
         }
+
+        if (_datepickers.length) { _destroyDatepickers(); }
 
         return [...datepickers].map(datepicker => _createDatepicker(datepicker));
     }

--- a/src/px-script/main/datepicker/index.js
+++ b/src/px-script/main/datepicker/index.js
@@ -58,8 +58,7 @@ const _createDatepicker = datepicker => {
 };
 
 const _destroyDatepickers = () => {
-    _datepickers.forEach(datepicker => datepicker.destroy());
-    _datepickers = [];
+    _datepickers = _datepickers.filter(datepicker => datepicker.destroy());
 };
 
 const init = id => {
@@ -73,7 +72,7 @@ const init = id => {
         }
 
         _datepickers.forEach((d, i) => (d.element.id === id
-            ? (d.destroy(), _datepickers.splice(i, 1))
+            ? _datepickers.splice(i, 1)[0].destroy()
             : null)
         );
 

--- a/src/px-script/main/datepicker/index.test.js
+++ b/src/px-script/main/datepicker/index.test.js
@@ -64,6 +64,18 @@ describe("px-script: datepicker", () => {
             expect(datepicker.init("test")).toBeNull();
             expect(console.warn).toHaveBeenCalled();
         });
+
+        it("destroys existing flatpickr instances", () => {
+            ReactDOM.render(<Datepicker id="test-datepicker" />, div);
+
+            datepicker.init();
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
+
+            datepicker.init();
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
+        });
     });
 
     it("warns about non-existing formats", () => {

--- a/src/px-script/main/datepicker/index.test.js
+++ b/src/px-script/main/datepicker/index.test.js
@@ -5,6 +5,8 @@ import datepicker from "./index";
 import Datepicker from "@/FormComponents/Datepicker";
 import formats from "./formats";
 
+// TODO: rewrite tests to mock flatpickr [AW]
+
 describe("px-script: datepicker", () => {
     const div = document.createElement("div");
 
@@ -64,17 +66,39 @@ describe("px-script: datepicker", () => {
             expect(datepicker.init("test")).toBeNull();
             expect(console.warn).toHaveBeenCalled();
         });
+    });
 
-        it("destroys existing flatpickr instances", () => {
-            ReactDOM.render(<Datepicker id="test-datepicker" />, div);
-
-            datepicker.init();
-
-            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
+    describe("_destroyDatepickers", () => {
+        it("destroys existing flatpickr instances on init()", () => {
+            ReactDOM.render(<Datepicker />, div);
 
             datepicker.init();
 
             expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
+
+            datepicker.init();
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
+        });
+
+        it("does not destroy existing flatpickr instances on init(id)", () => {
+            // Use default value because flatpickr is kept thorugh test cases [AW]
+            const defaultVal = document.querySelectorAll(".flatpickr-calendar").length;
+
+            ReactDOM.render(
+                <>
+                    <Datepicker id="test-1" />
+                    <Datepicker id="test-2" />
+                </>, div
+            );
+
+            datepicker.init("test-1");
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(defaultVal + 1);
+
+            datepicker.init("test-2");
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(defaultVal + 2);
         });
     });
 

--- a/src/px-script/main/datepicker/index.test.js
+++ b/src/px-script/main/datepicker/index.test.js
@@ -7,6 +7,10 @@ import formats from "./formats";
 
 // TODO: rewrite tests to mock flatpickr [AW]
 
+/*
+    NB: datepicker.init() resets the _datepickers array and destroys flatpickr instances only when at least one valid datepicker is found [AW]
+*/
+
 describe("px-script: datepicker", () => {
     const div = document.createElement("div");
 
@@ -66,9 +70,7 @@ describe("px-script: datepicker", () => {
             expect(datepicker.init("test")).toBeNull();
             expect(console.warn).toHaveBeenCalled();
         });
-    });
 
-    describe("_destroyDatepickers", () => {
         it("destroys existing flatpickr instances on init()", () => {
             ReactDOM.render(<Datepicker />, div);
 
@@ -81,10 +83,7 @@ describe("px-script: datepicker", () => {
             expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
         });
 
-        it("does not destroy existing flatpickr instances on init(id)", () => {
-            // Use default value because flatpickr is kept thorugh test cases [AW]
-            const defaultVal = document.querySelectorAll(".flatpickr-calendar").length;
-
+        it("destroys existing flatpickr instances on init(ID) if the given ID is already initialized", () => {
             ReactDOM.render(
                 <>
                     <Datepicker id="test-1" />
@@ -92,13 +91,25 @@ describe("px-script: datepicker", () => {
                 </>, div
             );
 
-            datepicker.init("test-1");
+            datepicker.init();
 
-            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(defaultVal + 1);
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(2);
 
             datepicker.init("test-2");
 
-            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(defaultVal + 2);
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(2);
+        });
+
+        it("doesn't destroy existing flatpickr instances on init(ID) if the given ID is invalid", () => {
+            ReactDOM.render(<Datepicker id="test-1" />, div);
+
+            datepicker.init();
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
+
+            datepicker.init("invalid-id");
+
+            expect(document.querySelectorAll(".flatpickr-calendar").length).toEqual(1);
         });
     });
 


### PR DESCRIPTION
Added code to clean up to delete old flatpickr instances when datepicker.init() is called more than once.