### PR TITLE
Remove uppercase for forms + more styling changes for forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Changed how labels, help-blocks, legends and placeholders appear.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Changed how labels, help-blocks, legends and placeholders appear.
+- Changed label, help-block, legend and placeholder appearance to improve readability.
 
 ### Fixed
 

--- a/src/less/components/forms/form.less
+++ b/src/less/components/forms/form.less
@@ -2,9 +2,7 @@ label {
     display: inline-block;
     max-width: 100%;
     margin-bottom: @base-margin-xs;
-    // font-weight: @font-weight-light;
-    font-size: @base-font-size;
-    color: @input-color;
+    font-size: @base-font-size * 0.9;
     line-height: 1.5;
 
     .required-asterisk {
@@ -153,8 +151,6 @@ legend {
     width: 100%;
     margin-bottom: @legend-bottom-margin;
     line-height: @base-font-size * 2.8;
-    font-weight: 300;
-    font-size: @base-font-size * 0.9;
     color: @legend-color;
     border: 0;
     border-bottom: 1px solid @legend-border-color;
@@ -187,7 +183,8 @@ legend {
 
     &::placeholder {
         color: @gray-6; /* Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526. */
-        opacity: 1;
+        font-weight: 300;
+        letter-spacing: -0.1px;
     }
 
     /* HTML5 says that controls under a fieldset > legend:first-child wont be
@@ -233,6 +230,7 @@ legend {
     margin: @helpblock-margin;
     color: lighten(@text-color, 25%);
     font-size: @base-font-size * 0.8;
+    font-style: italic;
     line-height: 1rem;
     min-height: 1rem;
 

--- a/src/less/components/forms/form.less
+++ b/src/less/components/forms/form.less
@@ -2,9 +2,8 @@ label {
     display: inline-block;
     max-width: 100%;
     margin-bottom: @base-margin-xs;
-    text-transform: uppercase;
-    font-weight: @font-weight-light;
-    font-size: @base-font-size * 0.9;
+    // font-weight: @font-weight-light;
+    font-size: @base-font-size;
     color: @input-color;
     line-height: 1.5;
 
@@ -154,7 +153,6 @@ legend {
     width: 100%;
     margin-bottom: @legend-bottom-margin;
     line-height: @base-font-size * 2.8;
-    text-transform: uppercase;
     font-weight: 300;
     font-size: @base-font-size * 0.9;
     color: @legend-color;
@@ -234,7 +232,6 @@ legend {
     display: block;
     margin: @helpblock-margin;
     color: lighten(@text-color, 25%);
-    text-transform: uppercase;
     font-size: @base-font-size * 0.8;
     line-height: 1rem;
     min-height: 1rem;

--- a/src/less/components/input-group.less
+++ b/src/less/components/input-group.less
@@ -29,6 +29,7 @@
         position: relative;
         flex: 1 1 auto;
         margin-bottom: 0;
+        color: @text-color;
 
         /* Add width 1% and flex-basis auto to ensure that button will not wrap out
          * the column. Applies to IE Edge+ and Firefox. Chrome does not require this. */


### PR DESCRIPTION
Labels, helpblocks and legends are now capitalized instead of uppercased to improve readability. Also made som changes to placeholder so it takes less focus.

closes #309 