### PR TITLE
Add .page-title class

### DIFF
--- a/src/App/Documentation/core/Typography/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/core/Typography/__snapshots__/index.test.js.snap
@@ -455,6 +455,81 @@ exports[`Core: Typography Lead renders 1`] = `
 </Fragment>
 `;
 
+exports[`Core: Typography PageTitle renders 1`] = `
+<Fragment>
+  <h2
+    id="page-title"
+  >
+    Page title
+  </h2>
+  <p>
+    To emphasize a heading, use 
+    <Property
+      value=".page-title"
+    />
+     to add a light gray border under a heading. This only works for heading tags and classes ( 
+    <PrismCode
+      className="language-html"
+      component="code"
+    >
+      &lt;h1&gt;
+    </PrismCode>
+    ... 
+    <PrismCode
+      className="language-html"
+      component="code"
+    >
+      &lt;h6&gt;
+    </PrismCode>
+    /
+    <Property
+      value=".h1"
+    />
+    ...
+    <Property
+      value=".h6"
+    />
+    );
+  </p>
+  <ComponentPreview
+    codeFigure={true}
+    language="html"
+    showCasePanel={true}
+  >
+    <h1
+      className="page-title"
+    >
+      Heading h1
+    </h1>
+    <h2
+      className="page-title"
+    >
+      Heading h2
+    </h2>
+    <h3
+      className="page-title"
+    >
+      Heading h3
+    </h3>
+    <h4
+      className="page-title"
+    >
+      Heading h4
+    </h4>
+    <h5
+      className="page-title"
+    >
+      Heading h5
+    </h5>
+    <h6
+      className="page-title"
+    >
+      Heading h6
+    </h6>
+  </ComponentPreview>
+</Fragment>
+`;
+
 exports[`Core: Typography Small renders 1`] = `
 <Fragment>
   <h2
@@ -517,6 +592,7 @@ exports[`Core: Typography renders 1`] = `
   </p>
   <Fonts />
   <Headings />
+  <PageTitle />
   <Small />
   <Lead />
   <Inline />

--- a/src/App/Documentation/core/Typography/index.js
+++ b/src/App/Documentation/core/Typography/index.js
@@ -46,6 +46,24 @@ const Headings = () => (
     </>
 );
 
+const PageTitle = () => (
+    <>
+        <h2 id="page-title">Page title</h2>
+        <p>
+            To emphasize a heading, use <Property value=".page-title" /> to add a light gray border under a heading.
+            This only works for heading tags and classes ( <PrismCode className="language-html">{"<h1>"}</PrismCode>... <PrismCode className="language-html">{"<h6>"}</PrismCode>/<Property value=".h1" />...<Property value=".h6"/>);
+        </p>
+        <ComponentPreview language="html" showCasePanel codeFigure>
+            <h1 className="page-title">Heading h1</h1>
+            <h2 className="page-title">Heading h2</h2>
+            <h3 className="page-title">Heading h3</h3>
+            <h4 className="page-title">Heading h4</h4>
+            <h5 className="page-title">Heading h5</h5>
+            <h6 className="page-title">Heading h6</h6>
+        </ComponentPreview>
+    </>
+);
+
 const Small = () => (
     <>
         <h2 id="small">Small</h2>
@@ -168,6 +186,7 @@ const Typography = () => (
         <p className="lead">Documentation and examples for PayEx DesignGuide typography.</p>
         <Fonts />
         <Headings />
+        <PageTitle />
         <Small />
         <Lead />
         <Inline />
@@ -180,4 +199,4 @@ const Typography = () => (
 export default Typography;
 
 /* For testing */
-export { Fonts, Headings, Small, Lead, Inline, TextUtilities, Abbreviations, Blockquotes };
+export { Fonts, Headings, PageTitle, Small, Lead, Inline, TextUtilities, Abbreviations, Blockquotes };

--- a/src/App/Documentation/core/Typography/index.test.js
+++ b/src/App/Documentation/core/Typography/index.test.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 
-import Typography, { Fonts, Headings, Small, Lead, Inline, TextUtilities, Abbreviations, Blockquotes } from "./index";
+import Typography, { Fonts, Headings, PageTitle, Small, Lead, Inline, TextUtilities, Abbreviations, Blockquotes } from "./index";
 
 describe("Core: Typography", () => {
     it("is defined", () => {
@@ -34,6 +34,18 @@ describe("Core: Typography", () => {
 
         it("renders", () => {
             const wrapper = shallow(<Headings />);
+
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+
+    describe("PageTitle", () => {
+        it("is defined", () => {
+            expect(PageTitle).toBeDefined();
+        });
+
+        it("renders", () => {
+            const wrapper = shallow(<PageTitle />);
 
             expect(wrapper).toMatchSnapshot();
         });

--- a/src/less/core/typography.less
+++ b/src/less/core/typography.less
@@ -21,6 +21,10 @@ h1, h2, h3, h4, h5, h6,
         line-height: @headings-line-height;
         vertical-align: text-top;
     }
+
+    &.page-title {
+        border-bottom: 1px solid @gray-9;
+    }
 }
 /* stylelint-enable selector-list-comma-newline-after */
 


### PR DESCRIPTION
Page title adds a faint gray border under a heading. Closes #324.