### PR TITLE
Add padding to select.form-control

### DIFF
--- a/src/less/components/input-group.less
+++ b/src/less/components/input-group.less
@@ -25,6 +25,12 @@
         }
     }
 
+    select {
+        &.form-control {
+            padding-right: 1.75rem;
+        }
+    }
+
     > .form-control {
         position: relative;
         flex: 1 1 auto;


### PR DESCRIPTION
This fixes the select arrow overlapping text, fixes #346.