### PR TITLE
Prepare patch 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 # Changelog
 
-## [2.X.X] - 2019-XX-XX
-
-### Added
-
-### Changed
+## [2.3.1] - 2019-11-04
 
 ### Fixed
 
-### Removed
+ - Bump eslint-utils from 1.3.1 to 1.4.3 for security reasons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## [2.3.1] - 2019-11-04
+## [2.3.1] - 2019-11-08
 
 ### Fixed
 
  - Bump eslint-utils from 1.3.1 to 1.4.3 for security reasons
+ - While we're at it, basically bump every node package that doesn't require a lot of refactoring because it's cool to be up-to-date

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # PayEx DesignGuide
 
-[![Version](https://img.shields.io/badge/Version-2.3.0-blue.svg)](https://github.com/PayEx/design.payex.com/releases/tag/2.3.0)
+[![Version](https://img.shields.io/badge/Version-2.3.1-blue.svg)](https://github.com/PayEx/design.payex.com/releases/tag/2.3.1)
 [![Build status](https://ci.appveyor.com/api/projects/status/1dii19sqw1m7xtsn/branch/master?svg=true)](https://ci.appveyor.com/project/PayEx/design-payex-com/branch/master)
 [![Code Coverage](https://codecov.io/gh/payex/design.payex.com/branch/master/graph/badge.svg)](https://codecov.io/gh/payex/design.payex.com)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=PayEx/design.payex.com)](https://dependabot.com)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "design.payex.com",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "design.payex.com",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "PayEx DesignGuide",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
# Changelog

## [2.3.1] - 2019-11-08

### Fixed
 - Bump eslint-utils from 1.3.1 to 1.4.3 for security reasons
 - While we're at it, basically bump every node package that doesn't require a lot of refactoring because it's cool to be up-to-date